### PR TITLE
Manage dependencies

### DIFF
--- a/Dockerfile-admiral
+++ b/Dockerfile-admiral
@@ -35,14 +35,13 @@ RUN echo "cisa ALL=(root) NOPASSWD: /usr/bin/nmap" > /etc/sudoers.d/cisa_nmap \
 
 RUN python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel
 
-RUN if [ -n "${INSTALL_IPYTHON}" ]; \
-  then python3 -m pip --no-cache-dir install ipython pytest; fi
-
 WORKDIR ${CISA_SRC}
 
 COPY src src
 COPY setup.py README.md ./
-RUN python3 -m pip --no-cache-dir install --editable .
+RUN if [ -n "${INSTALL_IPYTHON}" ]; \
+  then python3 -m pip --no-cache-dir install --editable .[test]; \
+  else python3 -m pip --no-cache-dir install --editable .; fi
 
 USER cisa
 WORKDIR ${CISA_HOME}

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,10 @@ setup(
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     include_package_data=True,
     install_requires=[
-        "celery >= 4.3.0rc2",
+        # Celery 5.0 introduces breaking changes to the CLI. See
+        # https://docs.celeryq.dev/en/stable/history/whatsnew-5.0.html?highlight=command%20line%20options#new-command-line-interface
+        # for more information.
+        "celery >= 4.3.0,<5.0.0",
         "cryptography >= 2.4.2",
         "defusedxml",
         "dnspython",

--- a/src/admiral/_version.py
+++ b/src/admiral/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Celery 5.0 introduces a new CLI that is not backwards-compatible. To avoid breaking changes, pin the versions of Celery which work with our implementation. 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

This change resolves Issue #7 and restores our ability to comply with [Emergency Directive 19-01](https://www.cisa.gov/emergency-directive-19-01).

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

I followed the instructions in `README.md` to run system and unit tests with `docker compose -f docker-compose-dev.yml run test`. All passed. Then I started a bash shell with `docker compose -f docker-compose-dev.yml run bash` and ran admiral on the last 1000 federal domains by alphabetical order with `./examples/load_certs.py -v --skipto==smokeybear.gov`. 

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.