### PR TITLE
Stabilize Admiral

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
     image: rediscommander/redis-commander:latest
     # build: .
     restart: always
+    depends_on:
+      - redis
     environment:
       - REDIS_HOSTS=default:redis:6379:0:fruitcake
     ports:

--- a/secrets/admiral.yml
+++ b/secrets/admiral.yml
@@ -8,6 +8,11 @@ celery-defaults: &celery-defaults
   result_backend: redis://:fruitcake@redis:6379/0
   result_expires: 3600
   task_acks_late: true
+  # According to https://groups.google.com/g/crtsh/c/NZJntKrBdmg,
+  # crt.sh requests are limited to 60 per minute. The default rate limit
+  # for tasks is applied to each worker individually. So since there are
+  # 6 cert workers, '10/m' honors the limit set by crt.sh.
+  task_default_rate_limit: 10/m
   task_reject_on_worker_lost: true
   task_track_started: true
   task_send_sent_event: true

--- a/src/admiral/certs/tasks.py
+++ b/src/admiral/certs/tasks.py
@@ -19,7 +19,8 @@ DOMAIN_NAME_RE = re.compile(
 
 # Default timeout values for tasks that perform web requests. See
 # "Warning' at https://docs.celeryq.dev/en/stable/userguide/tasks.html
-CONNECT_TIMEOUT, READ_TIMEOUT = 5.0, 30.0
+CONNECT_TIMEOUT = 5.0
+READ_TIMEOUT = 30.0
 
 
 @shared_task(

--- a/src/admiral/certs/tasks.py
+++ b/src/admiral/certs/tasks.py
@@ -17,6 +17,10 @@ DOMAIN_NAME_RE = re.compile(
     r"([a-z0-9]{2,63}|(?:[a-z0-9][a-z0-9\-]{0,61}[a-z0-9]))\.?$"
 )
 
+# Default timeout values for tasks that perform web requests. See
+# "Warning' at https://docs.celeryq.dev/en/stable/userguide/tasks.html
+CONNECT_TIMEOUT, READ_TIMEOUT = 5.0, 30.0
+
 
 @shared_task(
     autoretry_for=(Exception, requests.HTTPError, requests.exceptions.HTTPError),
@@ -46,8 +50,11 @@ def summary_by_domain(domain, subdomains=True, expired=False):
         f"https://crt.sh/?Identity={wildcard_param}{domain}{expired_param}"
         f"&output=json"
     )
-
-    req = requests.get(url, headers={"User-Agent": "cyhy/2.0.0"})
+    req = requests.get(
+        url,
+        headers={"User-Agent": "cyhy/2.0.0"},
+        timeout=(CONNECT_TIMEOUT, READ_TIMEOUT),
+    )
 
     if req.ok:
         data = json.loads(req.content)
@@ -70,7 +77,11 @@ def cert_by_id(id):
     logger.info(f"Fetching cert data from CT log for id: {id}.")
 
     url = f"https://crt.sh/?d={id}"
-    req = requests.get(url, headers={"User-Agent": "cyhy/2.0.0"})
+    req = requests.get(
+        url,
+        headers={"User-Agent": "cyhy/2.0.0"},
+        timeout=(CONNECT_TIMEOUT, READ_TIMEOUT),
+    )
 
     if req.ok:
         return req.content.decode()


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

The goal was to keep Admiral running in a steady state. That end precipitated two primary changes: (1) setting a default rate limit for Celery tasks; and (2) adding timeouts to certificate requests. 

## 💭 Motivation and context ##

<!-- Why is this change required? -->

The changes made in this PR resolve #16. Admiral no longer crashes on domains with a large number of certificates, but still struggles to process them. Admiral can be further stabilized by reducing the amount of time these queries take. I opened #20 to track work on this improvement.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

With these changes in place, I could process `ahrq.gov` -- the domain Admiral previously crashed on. And I have continued to run Admiral since without a crash. So far, I have processed 138 domains.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
