### PR TITLE
Reconfigure task rate limits

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ x-admiral-template: &admiral-template
     dockerfile: Dockerfile-admiral
   deploy:
     mode: replicated
-    replicas: 6
+    replicas: 5
   environment:
     ADMIRAL_CONFIG_FILE: "/run/secrets/admiral.yml"
     ADMIRAL_CONFIG_SECTION: dev-mode

--- a/secrets/admiral.yml
+++ b/secrets/admiral.yml
@@ -41,6 +41,8 @@ task_rate_limit: &task_rate_limit
   # Modify the rate below as needed. Limits are applied per worker, so
   # "2/h" means limit one worker to 2 tasks per hour. To get the global
   # rate limit, you must multiply by the number of workers provisioned.
+  # For more syntax examples, refer to
+  # https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.rate_limit
   rate_limit: "2/h"
 
 cert-worker: &default-section

--- a/secrets/admiral.yml
+++ b/secrets/admiral.yml
@@ -8,18 +8,8 @@ celery-defaults: &celery-defaults
   result_backend: redis://:fruitcake@redis:6379/0
   result_expires: 3600
   task_acks_late: true
-  task_reject_on_worker_lost: true
-  task_track_started: true
-  task_send_sent_event: true
-  task_default_queue: cyhy_default
   task_default_exchange: null
-  task_routes:
-    admiral.certs.*:
-      queue: cyhy_cert_work
-    admiral.port_scan.*:
-      queue: cyhy_scanner_work
-    admiral.tester.*:
-      queue: cyhy_test_work
+  task_default_queue: cyhy_default
   task_queues:
     cyhy_cert_work:
       routing_key: cyhy_cert_work
@@ -27,6 +17,16 @@ celery-defaults: &celery-defaults
       routing_key: cyhy_scanner_work
     cyhy_test_work:
       routing_key: cyhy_test_work
+  task_reject_on_worker_lost: true
+  task_routes:
+    admiral.certs.*:
+      queue: cyhy_cert_work
+    admiral.port_scan.*:
+      queue: cyhy_scanner_work
+    admiral.tester.*:
+      queue: cyhy_test_work
+  task_send_sent_event: true
+  task_track_started: true
 
 # used in the development container
 dev-mode:

--- a/secrets/admiral.yml
+++ b/secrets/admiral.yml
@@ -37,9 +37,15 @@ dev-mode:
     - admiral.port_scan
     - admiral.tester
 
+task_rate_limit: &task_rate_limit
+  # Modify the rate below as needed. "10/h" means limit to 10 request per hour.
+  rate_limit: '10/h'
+
 cert-worker: &default-section
   celery:
     <<: *celery-defaults
+    task_annotations:
+      tasks.summary_by_domain: *task_rate_limit
     task_default_queue: cyhy_cert_work
     task_queues:
       cyhy_cert_work:

--- a/secrets/admiral.yml
+++ b/secrets/admiral.yml
@@ -38,8 +38,10 @@ dev-mode:
     - admiral.tester
 
 task_rate_limit: &task_rate_limit
-  # Modify the rate below as needed. "10/h" means limit to 10 request per hour.
-  rate_limit: '10/h'
+  # Modify the rate below as needed. Limits are applied per worker, so
+  # "2/h" means limit one worker to 2 tasks per hour. To get the global
+  # rate limit, you must multiply by the number of workers provisioned.
+  rate_limit: "2/h"
 
 cert-worker: &default-section
   celery:

--- a/src/admiral/_version.py
+++ b/src/admiral/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/src/admiral/certs/tasks.py
+++ b/src/admiral/certs/tasks.py
@@ -28,7 +28,6 @@ READ_TIMEOUT = 30.0
 
 @shared_task(
     autoretry_for=(Exception, requests.HTTPError, requests.exceptions.HTTPError),
-    rate_limit="10/h",
     retry_backoff=True,
     retry_jitter=True,
     retry_kwargs={"max_retries": 16},


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
This pull request turns the `summary_by_domain` task rate limit into a configuration option. 
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

- Resolves #32 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

I tested these changes by configuring the admiral `cert-workers` to run with 2 different rate limits in place. The requests made to the [Certificate Transparency Search API](https://sslmate.com/ct_search_api/) were expected to succeed in one case and fail in the other. 

By default, the API permits a maximum of 10 requests per hour for full-domain certificate queries. In order to meet this limit, I had to account for the way in which Celery applies rate limits for tasks. Rate limits are applied on a _per-worker_ basis, so with 5 `cert-worker` replicas, I adjusted the rate limit to 2 requests per hour. This produced a global rate limit of 10 requests per hour. From there, I verified that requests completed successfully.

For the other case, I changed the rate limit to 1 request per second. As expected, this failed. The rate limit triggered HTTP 429 errors for generating too many requests.

See the screenshots below for the result of each case respectively.


## 📷 Screenshots ##
<img width="658" alt="Screen Shot 2023-01-31 at 1 44 12 PM" src="https://user-images.githubusercontent.com/55767786/215866047-74918c70-1efa-425e-974b-f0fecfc44916.png">
<img width="657" alt="Screen Shot 2023-01-31 at 1 50 24 PM" src="https://user-images.githubusercontent.com/55767786/215867350-e4029575-58ee-437a-a68b-523aae5600e6.png">

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
<!--
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
-->
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
<!--
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
-->
<!--
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] -->
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [x] Revert dependencies to default branches.
- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Add a tag or create a release.
