### PR TITLE
Fix crash on save

### DIFF
--- a/examples/load_certs.py
+++ b/examples/load_certs.py
@@ -143,7 +143,7 @@ def group_update_domain(domain, max_expired_date, verbose=False, dry_run=False):
         data = base64.b64decode(result["data"])  # encoded in ASN.1 DER
         pem = ssl.DER_cert_to_PEM_cert(data)
         cert, is_precert = Cert.from_pem(pem)
-        cert.log_id = task.get("args")[0]  # get log_id from task
+        cert.log_id = task.get("args")[0]["id"]  # get log_id from task
         if is_precert:
             # if this is a precert, we save to the precert collection
             with context_managers.switch_collection(Cert, "precerts"):

--- a/src/admiral/_version.py
+++ b/src/admiral/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.3.1"
+__version__ = "1.3.2"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This is a simple change to extract the `log_id` from the `cert_by_issuance` task. The line of code broke when we switched APIs.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

- Resolves #45 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

I didn't catch this bug earlier because I tested without saving certificates to the database. This time I did. I ran the `load_certs` script on the `opensource.gov` domain and successfully saved 100 certificates to the development database.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release.
