### PR TITLE
Update CT Search request

### DIFF
--- a/examples/load_certs.py
+++ b/examples/load_certs.py
@@ -140,7 +140,7 @@ def group_update_domain(domain, max_expired_date, verbose=False, dry_run=False):
 
     # create x509 certificates from the results
     for task, result in tasks_to_results:
-        data = base64.b64decode(result["data"])  # encoded in ASN.1 DER
+        data = base64.b64decode(result)  # encoded in ASN.1 DER
         pem = ssl.DER_cert_to_PEM_cert(data)
         cert, is_precert = Cert.from_pem(pem)
         cert.log_id = task.get("args")[0]["id"]  # get log_id from task

--- a/src/admiral/_version.py
+++ b/src/admiral/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.3.2"
+__version__ = "1.3.4"

--- a/src/admiral/certs/tasks.py
+++ b/src/admiral/certs/tasks.py
@@ -53,7 +53,7 @@ def summary_by_domain(domain, subdomains=True):
     logger.info(f"Fetching certs from CT log for: {domain}")
     url = (
         f"https://api.certspotter.com/v1/issuances?domain={domain}&include_subdomains={subdomains}"
-        f"&expand=dns_names&expand=cert"
+        f"&expand=dns_names&expand=cert_der"
     )
     req = requests.get(
         url,
@@ -82,4 +82,4 @@ def cert_by_issuance(issuance):
     id = issuance["id"]
     logger.info(f"Fetching cert data from CT log for id: {id}.")
 
-    return issuance["cert"]
+    return issuance["cert_der"]


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
I updated the [CT Search API](https://sslmate.com/help/reference/ct_search_api_v1) request to expand the new `cert_der` field. 
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
According to the [SSLMate Changelog](https://sslmate.com/help/changelog), on January 3rd 2023 the `cert` object was deprecated. You now use `cert_der` to retrieve certificate data. 
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
- Resolves #51 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

I verified that our tasks still function as expected with the changes in place. To test, I performed a dry run and monitored progress from the Celery Flower dashboard. The `summary_by_domain` task returned results with `cert_der` expanded, and the `cert_by_issuance` task returned the base64 representation of the DER-encoded certificate. I stopped the dry run after approximately 10 domains had been scanned.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Revert dependencies to default branches.
- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.

***Note:*** A  `v.1.3.4` release will not be built for these changes because the version is semantically incorrect. The `v1.3.3` release targets a fix at [3cfcde5](https://github.com/cisagov/admiral/commit/3cfcde515103330134966c1efc8bf44f16003fb5).
