### PR TITLE
Remove `shell=True` from nmap subprocess calls

### DIFF
--- a/src/admiral/port_scan/tasks.py
+++ b/src/admiral/port_scan/tasks.py
@@ -54,13 +54,9 @@ def run_it(command):
     logger.info(f"Executing command: {command}")
 
     try:
-        # TODO: flake8 gives a DUO116 error here about shell=True being
-        # unsafe, but we need to determine whether it is necessary
-        # before removing it.  See #106 for more details.
-        completed_process = subprocess.run(  # noqa: DUO116
+        completed_process = subprocess.run(
             command,
             capture_output=True,
-            shell=True,
             check=True,  # nosec
         )
     except subprocess.CalledProcessError as err:
@@ -83,14 +79,28 @@ def up_scan(ip):
     """
     # validate input
     valid_ip = ipaddress.ip_address(ip)
-    # nnap requires a `-6` option if the target is IPv6
+    # nmap requires a `-6` option if the target is IPv6
     # TODO: ICMP Timestamp and Address Mask pings are only valid for IPv4.
-    v6_flag = "-6 " if valid_ip.version == 6 else ""
+    v6_flag = ["-6"] if valid_ip.version == 6 else []
     ports = ",".join(str(i) for i in QUICK_PORTS)
-    nmap_command = (
-        f"sudo nmap {v6_flag}{valid_ip} --stats-every 60 -oX - "
-        f"-n -sn -T4 --host-timeout 15m -PE -PP -PS{ports}"
-    )
+    nmap_command = [
+        "sudo",
+        "nmap",
+        *v6_flag,
+        str(valid_ip),
+        "--stats-every",
+        "60",
+        "-oX",
+        "-",
+        "-n",
+        "-sn",
+        "-T4",
+        "--host-timeout",
+        "15m",
+        "-PE",
+        "-PP",
+        f"-PS{ports}",
+    ]
     completed_process = run_it(nmap_command)
     xml_string = completed_process.stdout.decode()
     data = bf.data(fromstring(xml_string, forbid_dtd=True))
@@ -110,14 +120,34 @@ def port_scan(ip):
     """
     # validate input
     valid_ip = ipaddress.ip_address(ip)
-    # nnap requires a `-6` option if the target is IPv6
-    v6_flag = "-6 " if valid_ip.version == 6 else ""
-    nmap_command = (
-        f"sudo nmap {v6_flag}{valid_ip} --stats-every 60 -oX - "
-        "-R -Pn -T4 --host-timeout 120m --max-scan-delay 5ms "
-        "--max-retries 2 --min-parallelism 32 "
-        "--defeat-rst-ratelimit -sV -O -sS -p1-65535"
-    )
+    # nmap requires a `-6` option if the target is IPv6
+    v6_flag = ["-6"] if valid_ip.version == 6 else []
+    nmap_command = [
+        "sudo",
+        "nmap",
+        *v6_flag,
+        str(valid_ip),
+        "--stats-every",
+        "60",
+        "-oX",
+        "-",
+        "-R",
+        "-Pn",
+        "-T4",
+        "--host-timeout",
+        "120m",
+        "--max-scan-delay",
+        "5ms",
+        "--max-retries",
+        "2",
+        "--min-parallelism",
+        "32",
+        "--defeat-rst-ratelimit",
+        "-sV",
+        "-O",
+        "-sS",
+        "-p1-65535",
+    ]
     completed_process = run_it(nmap_command)
     xml_string = completed_process.stdout.decode()
     data = bf.data(fromstring(xml_string, forbid_dtd=True))

--- a/tests/port_scan_tasks_test.py
+++ b/tests/port_scan_tasks_test.py
@@ -1,0 +1,51 @@
+"""Tests for helpers in admiral.port_scan.tasks."""
+
+# Standard Python Libraries
+from unittest.mock import Mock
+
+# Third-Party Libraries
+import pytest
+
+# cisagov Libraries
+from admiral.port_scan import tasks
+
+
+def test_run_it_calls_subprocess_without_shell(monkeypatch):
+    """Verify that run_it executes commands without shell=True."""
+    command = ["nmap", "127.0.0.1"]
+    completed_process = tasks.subprocess.CompletedProcess(
+        args=command,
+        returncode=0,
+        stdout=b"",
+        stderr=b"",
+    )
+    mock_run = Mock(return_value=completed_process)
+    monkeypatch.setattr(tasks.subprocess, "run", mock_run)
+
+    result = tasks.run_it(command)
+
+    mock_run.assert_called_once_with(
+        command,
+        capture_output=True,
+        check=True,
+    )
+    assert result.returncode == 0
+
+
+def test_run_it_logs_stderr_on_failure(monkeypatch):
+    """Verify that run_it logs and re-raises subprocess failures."""
+    command = ["nmap", "127.0.0.1"]
+    error = tasks.subprocess.CalledProcessError(
+        returncode=1,
+        cmd=command,
+        stderr=b"nmap failed",
+    )
+    mock_run = Mock(side_effect=error)
+    mock_logger = Mock()
+    monkeypatch.setattr(tasks.subprocess, "run", mock_run)
+    monkeypatch.setattr(tasks, "logger", mock_logger)
+
+    with pytest.raises(tasks.subprocess.CalledProcessError):
+        tasks.run_it(command)
+
+    mock_logger.error.assert_called_once_with("nmap failed")


### PR DESCRIPTION
This switches port scan command execution away from shell strings by building explicit argument lists for nmap calls.

I also added focused unit tests for `run_it` to verify it calls `subprocess.run` without `shell=True` and still logs and re-raises command failures.

Fixes #107