### PR TITLE
Fix regex to allow single-character domain labels

### DIFF
--- a/src/admiral/_version.py
+++ b/src/admiral/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "3.0.1"
+__version__ = "3.0.2"

--- a/src/admiral/certs/tasks.py
+++ b/src/admiral/certs/tasks.py
@@ -14,23 +14,27 @@ from .._version import __version__
 
 logger = get_task_logger(__name__)
 
-# A single domain label as accepted by this project: 2 to 63 lowercase
-# alphanumeric characters with hyphens permitted in between.  This is stricter
-# than RFC 1035 (which allows 1-char labels and is case-insensitive) because the
-# original regex enforced the same constraints and the CT-log queries only need
-# lowercase FQDNs.  Validating one label at a time avoids the catastrophic
-# backtracking the previous combined regex was flagged for (flake8 DUO138 /
-# ReDoS); see #106.
-LABEL_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$")
+# This regex matches a single domain label as accepted by this project:
+# a string containing 1-63 characters from the set [a-z0-9-] that does
+# not start or end with a hyphen.
+#
+# This is stricter than RFC 1035 (which is case-insensitive) because the
+# CT-log queries only need lowercase FQDNs.
+#
+# Note that validating one label at a time avoids the catastrophic
+# backtracking the previous combined regex was flagged for (flake8
+# DUO138 / ReDoS); see #106.
+LABEL_RE = re.compile(r"^(?!-)[a-z0-9-]{1,63}(?<!-)$")
 
 
 def is_valid_domain_name(domain):
     """Return True if *domain* passes this project's domain-name rules.
 
-    Rules: two or more labels, each 2-63 lowercase alphanumeric characters
-    (hyphens allowed in the middle), with an optional trailing dot (FQDN form).
-    These constraints are intentionally stricter than RFC 1035 because they
-    mirror the original regex and match the CT-log query requirements.
+    Rules: two or more labels, each 1-63 lowercase alphanumeric
+      characters(hyphens allowed in the middle), with an optional
+      trailing dot (FQDN form).  These constraints are intentionally
+      stricter than RFC 1035 (which is case-insensitive) because
+      CT-log queries only require lowercase FQDNs.
     """
     if not isinstance(domain, str):
         return False

--- a/tests/cert_test.py
+++ b/tests/cert_test.py
@@ -56,13 +56,14 @@ def celery():
         ("example.com.", True),  # a single trailing dot (FQDN form) is allowed
         ("a-b.c-d.com", True),  # hyphens are permitted inside labels
         ("cyber.dhs.gov", True),
+        ("a.com", True),  # Single-character labels are allowed...
+        ("-.com", False),  # ...but not if they only contain a hyphen
         ("a..com", False),  # consecutive dots produce an empty label
         ("-bad.com", False),  # a label may not start with a hyphen
         ("bad-.com", False),  # a label may not end with a hyphen
         ("a", False),  # at least two labels are required
         ("", False),
         (None, False),  # non-string input should be rejected
-        ("x.co", False),  # single-character labels are not accepted by this validator
         (("a" * 63) + ".com", True),  # 63-character labels are permitted
         (("a" * 64) + ".com", False),  # a label may not exceed 63 characters
     ],


### PR DESCRIPTION
## 🗣 Description ##

This pull request corrects a regex to allow single-character domain labels.

## 💭 Motivation and context ##

Resolves #115.

## 🧪 Testing ##

All automated tests pass, including the new tests I added to cover the case of a single-character domain label.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release (necessary if and only if the version was bumped).
