### PR TITLE
Add a missing space character in a comment

### DIFF
--- a/src/admiral/certs/tasks.py
+++ b/src/admiral/certs/tasks.py
@@ -31,7 +31,7 @@ def is_valid_domain_name(domain):
     """Return True if *domain* passes this project's domain-name rules.
 
     Rules: two or more labels, each 1-63 lowercase alphanumeric
-      characters(hyphens allowed in the middle), with an optional
+      characters (hyphens allowed in the middle), with an optional
       trailing dot (FQDN form).  These constraints are intentionally
       stricter than RFC 1035 (which is case-insensitive) because
       CT-log queries only require lowercase FQDNs.


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes a typo in a comment where a necessary space character was missing.

## 💭 Motivation and context ##

@mcdonnnj pointed this out in #116 just after I merged it :melting_face: 

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.